### PR TITLE
add small padding to link buttons on mobile and thin screens

### DIFF
--- a/themes/nav-community-v1/static/css/style.css
+++ b/themes/nav-community-v1/static/css/style.css
@@ -3444,6 +3444,9 @@ ul li.cat-item a {
   .project-more {
     display:none;
   }
+  .themeix-button-group a {
+    margin-top: 5px;
+  }	
 }
 
 .roadmap-icon {


### PR DESCRIPTION
See issue #67 

This adds margin only on thin screened devices, prevent overflown buttons from "sticking" to the line above