### PR TITLE
Updated github links

### DIFF
--- a/content/projects/cold-staking/index.md
+++ b/content/projects/cold-staking/index.md
@@ -18,7 +18,7 @@ show_on_roadmap: true
 show_on_projects: false
 allow_click_through: false
 percent_complete: 100
-github_url: "https://github.com/navcoin/navcoin-core/tree/v4.1.2-cold-staking"
+github_url: "https://github.com/NAVCoin/npips/blob/master/npip-0002.mediawiki"
 project_url: ""
 reddit_url: ""
 twitter_url: ""

--- a/content/projects/community-fund/index.md
+++ b/content/projects/community-fund/index.md
@@ -20,7 +20,7 @@ show_on_roadmap: true
 show_on_projects: true
 allow_click_through: true
 percent_complete: 100
-github_url: "https://github.com/navcoin/navcoin-core/tree/v4.1.2-cfund"
+github_url: "https://github.com/NAVCoin/navcoin-core/tree/cfund-test"
 project_url: ""
 reddit_url: ""
 twitter_url: ""

--- a/content/projects/open-alias/index.md
+++ b/content/projects/open-alias/index.md
@@ -18,7 +18,7 @@ show_on_roadmap: true
 show_on_projects: true
 allow_click_through: true
 percent_complete: 100
-github_url: "https://github.com/aguycalled/openalias-register"
+github_url: "https://github.com/NAVCoin/navcoin-core/pull/213"
 project_url: "http://openalias.nav.community"
 reddit_url: ""
 twitter_url: ""


### PR DESCRIPTION
For cold staking, community fund, openalias. The old links were showing either 404, or were outdated.