### PR TITLE
Added pagination to news

### DIFF
--- a/themes/nav-community-v1/layouts/news/list.html
+++ b/themes/nav-community-v1/layouts/news/list.html
@@ -10,69 +10,57 @@
 <div class="appix-blog-content section-ptb-2">
     <div class="container">
 
-      {{ $list := (.Data.Pages) }}
-      {{ $len := (len $list) }}
+        {{ $list := (.Data.Pages) }}
+        {{ $len := (len $list) }}
 
-      {{ $last := (sub $len 1) }}
+        {{ $last := (sub $len 1) }}
+            {{ range .Paginator.Pages }}
 
-            {{ range $index, $element := .Data.Pages }}
-
-              {{ if (eq (mod $index 2) 0) }}
-              <div class="row">
-              {{ end }}
-
-              <div class="col-xs-12 col-sm-6">
-                  <div class="blog-item">
-                    {{ if isset .Params "generated_by_cms" }}
-                      <a href="{{ .URL }}">
-                        <div class="blog-image" style="background-image:url({{ .Params.feature_image }});">
-                            <div class="item-overlay"></div>
+            <div class="col-xs-12 col-sm-6">
+                <div class="blog-item">
+                {{ if isset .Params "generated_by_cms" }}
+                    <a href="{{ .URL }}">
+                    <div class="blog-image" style="background-image:url({{ .Params.feature_image }});">
+                        <div class="item-overlay"></div>
+                    </div>
+                    </a>
+                {{else}}
+                    <a href="{{ .URL }}">
+                        <div class="blog-image" style="background-image:url({{ .URL }}/{{ .Params.feature_image }});">
+                        <div class="item-overlay"></div>
                         </div>
-                      </a>
-                    {{else}}
-                      <a href="{{ .URL }}">
-                          <div class="blog-image" style="background-image:url({{ .URL }}/{{ .Params.feature_image }});">
-                            <div class="item-overlay"></div>
-                          </div>
-                      </a>
-                    {{ end }}
-                      <div class="blog-details">
-                          <h3><a href="{{ .URL }}">{{ .Title }}</a></h3>
-                          <ul class="blog-author-name">
-                              <li><i class="fa fa-user-o"></i>{{ .Params.author }}</li>
-                              <li>
-                                  <i class="fa fa-calendar"></i>
-                                  {{ dateFormat "2 Jan 2006" .Params.date }}
-                              </li>
-
-                          </ul>
-                          <ul class="blog-author-name">
-                              {{ range .Params.categories }}
-                              <li><i class="fa fa-folder-open-o"></i>{{.}} </li>
-                              {{end}}
-
-                          </ul>
-                          <div class="blog-excerpt">
-                              {{.Summary}}
-                          </div>
-                          <div class="read-more">
-                              <div class="themeix-button-group">
-                                  <a href="{{ .URL }}" class="themeix-btn themeix-danger">read more</a>
-                              </div>
-                          </div>
-                          {{ partial "social_share.html" . }}
-                      </div>
-                  </div>
-              </div>
-
-              {{ if (eq (mod $index 2) 1)}}
-              </div>
-              {{ else }}
-                {{ if (eq $index $last)}}
-                </div>
+                    </a>
                 {{ end }}
-              {{ end }}
+                    <div class="blog-details">
+                        <h3><a href="{{ .URL }}">{{ .Title }}</a></h3>
+                        <ul class="blog-author-name">
+                            <li><i class="fa fa-user-o"></i>{{ .Params.author }}</li>
+                            <li>
+                                <i class="fa fa-calendar"></i>
+                                {{ dateFormat "2 Jan 2006" .Params.date }}
+                            </li>
+
+                        </ul>
+                        <ul class="blog-author-name">
+                            {{ range .Params.categories }}
+                            <li><i class="fa fa-folder-open-o"></i>{{.}} </li>
+                            {{end}}
+
+                        </ul>
+                        <div class="blog-excerpt">
+                            {{.Summary}}
+                        </div>
+                        <div class="read-more">
+                            <div class="themeix-button-group">
+                                <a href="{{ .URL }}" class="themeix-btn themeix-danger">read more</a>
+                            </div>
+                        </div>
+                        {{ partial "social_share.html" . }}
+                    </div>
+                </div>
+            </div>
             {{end}}
+            {{ template "pagination.html" . }}
         </div>
     </div>
 </div>

--- a/themes/nav-community-v1/layouts/pagination.html
+++ b/themes/nav-community-v1/layouts/pagination.html
@@ -1,0 +1,47 @@
+{{ $pag := $.Paginator }}
+{{ if gt $pag.TotalPages 1 }}
+<div class="pagination-container">
+<ul class="nav-pagination">
+      {{ with $pag.First }}
+        <li>
+            <a href="{{ .URL }}" aria-label="First"><span aria-hidden="true">&laquo;&laquo;</span></a>
+        </li>
+      {{ end }}
+      <li      
+        {{ if not $pag.HasPrev }}
+          class="disabled"
+        {{ end }}
+      >
+        <a href="{{ if $pag.HasPrev }}{{ $pag.Prev.URL }}{{ end }}" aria-label="Previous"><span aria-hidden="true">&laquo;</span></a>
+      </li>
+      {{ $.Scratch.Set "__paginator.ellipsed" false }}
+      {{ range $pag.Pagers }}
+      {{ $right := sub .TotalPages .PageNumber }}
+      {{ $showNumber := or (le .PageNumber 3) (eq $right 0) }}
+      {{ $showNumber := or $showNumber (and (gt .PageNumber (sub $pag.PageNumber 2)) (lt .PageNumber (add $pag.PageNumber 2)))  }}
+      {{ if $showNumber }} 
+          {{ $.Scratch.Set "__paginator.ellipsed" false }}
+          {{ $.Scratch.Set "__paginator.shouldEllipse" false }}
+      {{ else }}
+          {{ $.Scratch.Set "__paginator.shouldEllipse" (not ($.Scratch.Get "__paginator.ellipsed") ) }}
+          {{ $.Scratch.Set "__paginator.ellipsed" true }}
+      {{ end }}
+      {{ if $showNumber }}
+      <li
+      {{ if eq . $pag }}class="active"{{ end }}><a href="{{ .URL }}" class="page-number">{{ .PageNumber }}</a></li>
+      {{ else if ($.Scratch.Get "__paginator.shouldEllipse") }}
+      <li ><span class="ellipse">&hellip;</span></li>
+      {{ end }}
+      {{ end }}
+      <li
+      {{ if not $pag.HasNext }}class="disabled"{{ end }}>
+      <a href="{{ if $pag.HasNext }}{{ $pag.Next.URL }}{{ end }}" aria-label="Next"><span>&raquo;</span></a>
+      </li>
+      {{ with $pag.Last }}
+      <li>
+          <a href="{{ .URL }}" aria-label="Last"><span>&raquo;&raquo;</span></a>
+      </li>
+      {{ end }}
+  </ul>
+</div> 
+{{ end }}

--- a/themes/nav-community-v1/static/css/responsive.css
+++ b/themes/nav-community-v1/static/css/responsive.css
@@ -1,3 +1,43 @@
+.pagination-container {
+  display: flex;
+  justify-content: center;
+  flex-direction: row;
+  width: 100%;
+  margin-bottom: 20px;
+}
+
+.nav-pagination li {
+  display: inline;
+}
+
+.nav-pagination .active a.page-number,
+.nav-pagination li a.page-number:hover, .nav-pagination li a.page-number:focus, .nav-pagination li a.page-number:active ,
+.nav-pagination li a:hover span, .nav-pagination li a:focus span, .nav-pagination li a:active span {
+  background-color: #337ab7;
+}
+
+.nav-pagination .ellipse {
+  /* background-color: #337ab7; */
+}
+
+.nav-pagination li a.page-number, .nav-pagination li span{
+  padding: 8px 12px;
+  margin-left: -1px;
+  line-height: 1.42857143;
+  color: #337ab7;
+  text-decoration: none;
+  background-color: #fff;
+  border: 1px solid #ddd;
+  font-weight: 400;
+  color: #fff;
+  font-size: 16px;
+  background: #CCCCCC;
+  margin-right: 8px;
+  -webkit-transition: all .5s;
+  -o-transition: all .5s;
+  transition: all .5s;
+}
+
 /* Normal Desktop:1366px */
 @media(min-width: 1170px) and (max-width: 1400px){
     .navbar-nav li a {


### PR DESCRIPTION
Now the news page will display a max of 10 notices, there is new navigation added to the bottom of the page used to change pages.
This GREATLY improves loading times.

Old Page: 
<img width="619" alt="image" src="https://user-images.githubusercontent.com/12672050/47974510-d2f71500-e10e-11e8-87e1-5c2d6781f1a3.png">

New Page: 
<img width="581" alt="image" src="https://user-images.githubusercontent.com/12672050/47974550-0043c300-e10f-11e8-8f14-8e32c1fa339c.png">

### ~40 second faster load time (tested using Firefox's 'wifi' speed preset)

