### PR TITLE
Proposal: Static Medium feed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules/
 public
 /themes/navhub-v2/static/css/nav.css
 /themes/navhub-v2/static/css/nav.css.map
+data/medium.json

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,7 @@ HUGO_VERSION = "0.53"
 
 [build]
 publish = "public"
-command = "gulp sass && hugo"
+command = "gulp sass && npm run data-medium && hugo"
 
 [[redirects]]
   from = "https://navcore.org/*"
@@ -85,4 +85,3 @@ command = "gulp sass && hugo"
   to = "https://navhub.org/assets"
   status = 301
   force = true
-  

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "webpack-cli": "^3.3.5"
   },
   "scripts": {
+    "data-medium": "mkdir -p data && node tools/rss-to-json.js https://medium.com/feed/nav-coin?limit=8 ./data/medium.json",
     "start": "hugo server",
     "sass": "gulp sass:watch",
     "build": "webpack --mode production",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "webpack-cli": "^3.3.5"
   },
   "scripts": {
-    "data-medium": "mkdir -p data && node tools/rss-to-json.js https://medium.com/feed/nav-coin?limit=8 ./data/medium.json",
+    "data-medium": "mkdir -p data && node tools/rss-to-json.js https://medium.com/feed/nav-coin ./data/medium.json",
     "start": "hugo server",
     "sass": "gulp sass:watch",
     "build": "webpack --mode production",

--- a/themes/navhub-v2/layouts/home.html
+++ b/themes/navhub-v2/layouts/home.html
@@ -14,13 +14,13 @@
                 <span class="fa fa-chevron-right"></span>
             </a>
         </div>
-        <div id="react-latest-news">
-            <div class="status-container">
-                <h3>Loading...</h3>
-            </div>
+        <div id="latest-news" class="card-container">
+            {{ range first 8 .Site.Data.medium.items }}
+                {{ partial "news/news_card.html" . }}
+            {{ end }}
         </div>
     </div>
-    
+
     {{ partial "home/projects_section.html" . }}
 
     {{ partial "home/events_section.html" . }}
@@ -30,10 +30,6 @@
     {{ partial "home/call_to_action.html" . }}
 
     {{ partial "footer.html" . }}
-
-    <!-- React components. -->
-    <script src="/js/react/vendor.bundle.js"></script>
-    <script src="/js/react/latest-news.js"></script>
 
 </body>
 </html>

--- a/themes/navhub-v2/layouts/partials/news/news_card.html
+++ b/themes/navhub-v2/layouts/partials/news/news_card.html
@@ -1,0 +1,15 @@
+<div class="homepage-news-card">
+    <a href="{{ .link }}}" target="_blank">
+      <div class="title-container"><h1>{{ .title }}</h1></div>
+      <div class="lower-section">
+          <div class="project-author">
+              <span class="fa fa-user-circle-o"></span>
+              {{ .creator }}
+          </div>
+          <div class="project-date">
+              <span class="fa fa-calendar"></span>
+              <span>{{ dateFormat "2 January 2006" .pubDate }} </span>
+          </div>
+      </div>
+    </a>
+</div>

--- a/themes/navhub-v2/static/css/sass/homepage/news_section.scss
+++ b/themes/navhub-v2/static/css/sass/homepage/news_section.scss
@@ -3,7 +3,7 @@
   src: url(/fonts/BIG-JOHN.otf);
 }
 
-#react-latest-news {
+#latest-news {
   min-height: 253px;
 }
 
@@ -119,6 +119,7 @@
         }
         .fa {
           margin-right: 5px;
+          color: #7d5ab5;
         }
       }
     }

--- a/tools/rss-to-json.js
+++ b/tools/rss-to-json.js
@@ -1,0 +1,35 @@
+/*
+
+Download an RSS feed, parse, and save it to a file.
+
+Usage:
+node rss-to-json url-to-rss output.json
+
+*/
+
+
+const fs = require("fs");
+const path = require("path");
+const Parser = require("rss-parser");
+const parser = new Parser();
+const [ url, outputPath ] = process.argv.slice(2);
+
+function save(err, feed) {
+  if (err !== null) {
+    const { message, stack, status } = err;
+    console.log("error parsing", url, message, stack, status)
+    return
+  }
+
+  const outputSource = JSON.stringify(feed, null, "  ");
+  fs.writeFile(outputPath, outputSource, function (err) {
+    if (err !== null) {
+      const { message, stack } = err;
+      console.log("error saving", outputPath, message, stack, status)
+      return
+    }
+    console.log("saved", outputPath)
+  })
+}
+
+parser.parseURL(url, save);


### PR DESCRIPTION
### Description

#267 adds the Medium RSS feed and components. This PR just makes it static. No request needs to be made if you do it like this.

The parser is moved to `./tools/rss-to-json.js` and might be reused if other feeds are tapped. Netlify should pull the data before hugo renders.

If you like this approach the React stuff can be backed up and used as a starting point for #269.

### Issues Resolved

None are resolved. #265 #267 related.

### Preview Links

https://deploy-preview-276--navhub.netlify.com/

It has the same appearance.

<img width="1440" alt="Screen Shot 2020-01-03 at 1 33 08 PM" src="https://user-images.githubusercontent.com/1634015/71747925-358c9380-2e2e-11ea-8ecf-27acffcd7c18.png">

With a blocker this section will still render.

<img width="468" alt="Screen Shot 2020-01-03 at 1 28 05 PM" src="https://user-images.githubusercontent.com/1634015/71747938-43daaf80-2e2e-11ea-8005-983700fcb305.png">


### Checklist

- [ ] Have you assigned/claimed the issues you've resolved in this pull request?
- [ ] Have the issues been moved to the QA column of the NavCoin Websites project? 
- [x] Have you checked there are no merge conflicts?
- [x] Have you tested the changes work across both mobile and desktop?

Mobile emulator view

<img width="313" alt="Screen Shot 2020-01-03 at 1 39 55 PM" src="https://user-images.githubusercontent.com/1634015/71747997-7a182f00-2e2e-11ea-82f2-1b005a235d90.png">

